### PR TITLE
Use template instead of stylesheet directory

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -28,7 +28,7 @@ if ( ! function_exists( 'understrap_scripts' ) ) {
 	 */
 	function understrap_scripts() {
 
-		wp_enqueue_style( 'understrap-styles', get_stylesheet_directory_uri() . '/'. asset_path('css/theme.min.css'), array(), null);
+		wp_enqueue_style( 'understrap-styles', get_template_directory_uri() . '/'. asset_path('css/theme.min.css'), array(), null);
 
 		wp_enqueue_script( 'jquery');
 		wp_enqueue_script( 'popper-scripts', get_template_directory_uri() . '/js/popper.min.js', array(), false, true);


### PR DESCRIPTION
Using the template directory instead of the stylesheet directory avoid a bug in simple child theme which are not rebuilding a complete CSS file from the understrap stylesheet.